### PR TITLE
A better identification of sbt projects

### DIFF
--- a/index.js
+++ b/index.js
@@ -546,16 +546,45 @@ const createJavaBom = async (
     );
   }
   // scala sbt
-  let sbtFiles = utils.getAllFiles(
+  // Identify sbt projects via its `project` directory:
+  // - all SBT project _should_ define build.properties file with sbt version info
+  // - SBT projects _typically_ have some configs/plugins defined in .sbt files
+  // - SBT projects that are still on 0.13.x, can still use the old approach,
+  //   where configs are defined via Scala files
+  // Detecting one of those should be enough to determine an SBT project.
+  let sbtProjectFiles = utils.getAllFiles(
     path,
-    (options.multiProject ? "**/" : "") + "build.sbt"
+    (options.multiProject ? "**/" : "") + "project/{build.properties,*.sbt,*.scala}"
   );
+
+  let sbtProjects = [];
+  for (let i in sbtProjectFiles) {
+    // parent dir of sbtProjectFile is the `project` directory
+    // parent dir of `project` is the sbt root project directory
+    const baseDir = pathLib.dirname(pathLib.dirname(sbtProjectFiles[i]));
+    sbtProjects = sbtProjects.concat(baseDir)
+  }
+
+  // Fallback in case sbt's project directory is non-existent
+  if (!sbtProjects.length) {
+    sbtProjectFiles = utils.getAllFiles(
+      path,
+      (options.multiProject ? "**/" : "") + "*.sbt"
+    );
+    for (let i in sbtProjectFiles) {
+      const baseDir = pathLib.dirname(sbtProjectFiles[i]);
+      sbtProjects = sbtProjects.concat(baseDir)
+    }
+  }
+
+  sbtProjects = [...new Set(sbtProjects)] // eliminate duplicates
+
   let sbtLockFiles = utils.getAllFiles(
     path,
     (options.multiProject ? "**/" : "") + "build.sbt.lock"
   );
 
-  if (sbtFiles && sbtFiles.length) {
+  if (sbtProjects && sbtProjects.length) {
     let pkgList = [];
     // If the project use sbt lock files
     if (sbtLockFiles && sbtLockFiles.length) {
@@ -584,9 +613,8 @@ const createJavaBom = async (
       const sbtPluginDefinition = `\naddSbtPlugin("io.shiftleft" % "sbt-dependency-graph" % "0.10.0-append-to-file3")\n`
       fs.writeFileSync(tempSbtPlugins, sbtPluginDefinition);
 
-      for (let i in sbtFiles) {
-        const f = sbtFiles[i];
-        const basePath = pathLib.dirname(f);
+      for (let i in sbtProjects) {
+        const basePath = sbtProjects[i];
         let dlFile = pathLib.join(tempDir, "dl-" + i + ".tmp");
         console.log(
           "Executing",
@@ -667,7 +695,7 @@ const createJavaBom = async (
         ptype: "maven",
         context: {
           src: path,
-          filename: sbtFiles.join(", "),
+          filename: sbtProjects.join(", "),
           nsMapping: jarNSMapping,
         },
       },


### PR DESCRIPTION
Switched to identifying sbt projects via its `project` directory:
 - all SBT project _should_ define build.properties file with sbt version info
 - SBT projects _typically_ have some configs/plugins defined in .sbt files
 - SBT projects that are still on 0.13.x, can still use the old approach,
   where configs are defined via Scala files
Detecting one of those should be enough to determine an SBT project.

In case none of those yields a success, fallback to the old behaviour
where we just search for .sbt files everywhere. Most of the
well-defined projects `project` directory will fall in the first
category.