### PR TITLE
Wrap sbt commands in quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -629,10 +629,10 @@ const createJavaBom = async (
         var sbtArgs = [];
         var pluginFile = null;
         if (standalonePluginFile) {
-          sbtArgs = [`-addPluginSbtFile=${tempSbtPlugins}`,`dependencyList::toFile "${dlFile}" --append`]
+          sbtArgs = [`-addPluginSbtFile=${tempSbtPlugins}`,`"dependencyList::toFile ${dlFile} --append"`]
         } else {
           // write to the existing plugins file
-          sbtArgs = [`dependencyList::toFile "${dlFile}" --append`]
+          sbtArgs = [`"dependencyList::toFile ${dlFile} --append"`]
           pluginFile = utils.addPlugin(basePath, sbtPluginDefinition);
         }
         const result = spawnSync(


### PR DESCRIPTION
Necessary when invoking sbt via shell.
Partial revert of the previous changes.