### PR TITLE
Upgrade cyclonedx maven plugin to 2.3.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -412,7 +412,7 @@ const createJavaBom = async (
       "-DremoteRepositories=central::default::https://repo.maven.apache.org/maven2,jitpack::::https://jitpack.io",
       "-DrepoUrl=https://jitpack.io",
       "-Dartifact=com.github.everit-org.json-schema:org.everit.json.schema:1.12.1",
-      "org.cyclonedx:cyclonedx-maven-plugin:2.2.0:makeAggregateBom",
+      "org.cyclonedx:cyclonedx-maven-plugin:2.3.0:makeAggregateBom",
     ];
     // Support for passing additional settings and profile to maven
     if (process.env.MAVEN_EXTRA_OPTS) {


### PR DESCRIPTION
Upgrade cyclonedx maven plugin to 2.3.0 which no longer use jitpack