### PR TITLE
Removed jitpack completely

### DIFF
--- a/index.js
+++ b/index.js
@@ -408,11 +408,7 @@ const createJavaBom = async (
   if (pomFiles && pomFiles.length) {
     let pkgList = [];
     let mvnArgs = [
-      "dependency:get",
-      "-DremoteRepositories=central::default::https://repo.maven.apache.org/maven2,jitpack::::https://jitpack.io",
-      "-DrepoUrl=https://jitpack.io",
-      "-Dartifact=com.github.everit-org.json-schema:org.everit.json.schema:1.12.1",
-      "org.cyclonedx:cyclonedx-maven-plugin:2.3.0:makeAggregateBom",
+      "org.cyclonedx:cyclonedx-maven-plugin:2.3.0:makeAggregateBom"
     ];
     // Support for passing additional settings and profile to maven
     if (process.env.MAVEN_EXTRA_OPTS) {


### PR DESCRIPTION
2.3.0 no longer requires jitpack. Tested with a client and locally by disabling jitpack.io via hosts file.