### PR TITLE
Temporarily disable license fetching

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,9 @@ function addComponent(
       return;
     }
     let version = pkg.version;
-    let licenses = utils.getLicenses(pkg, format);
+    //TODO: cherry-pick from upstream optional license fetching
+    //let licenses = utils.getLicenses(pkg, format);
+    let licenses = [];
     let purl = new PackageURL(
       ptype,
       group,


### PR DESCRIPTION
These are killing any BOM generation, especially for projects with a
large number of dependencies (normal in Go).
Will bring this back once the change from upstream is backported to this
fork and we make this optional.