### PR TITLE
7977: Bring back support for complex sbt projects

### DIFF
--- a/index.js
+++ b/index.js
@@ -725,6 +725,7 @@ const createJavaBom = async (
             sbtArgs = [`"dependencyList::toFile ${dlFile} --append"`]
             pluginFile = utils.addPlugin(basePath, sbtPluginDefinition);
           }
+          // Note that the command has to be invoked with `shell: true` to properly execut sbt
           const result = spawnSync(
             SBT_CMD,
             sbtArgs,


### PR DESCRIPTION
SBT project doesn't have to be defined at the root level of project.
Instead it can be defined in the project definition directory. This is
not recommended but still possible, especially for 0.13.x projects.

This change mostly brings back changes that were made in
https://github.com/ShiftLeftSecurity/cdxgen/commit/a11d7fe1387d94831b32c5f69fc281796b9d71e5
but were override when syncing with upstream in
https://github.com/ShiftLeftSecurity/cdxgen/pull/14