### PR TITLE
Introduce subproject parameter

### DIFF
--- a/bin/cdxgen
+++ b/bin/cdxgen
@@ -18,6 +18,10 @@ const args = require("yargs")
     type: "boolean",
     description: "Recurse mode suitable for mono-repos",
   })
+  .option("subproject", {
+    alias: "s",
+    description: "Analyze only a specific subproject",
+  })
   .option("resolve-class", {
     alias: "c",
     type: "boolean",
@@ -72,6 +76,7 @@ if (process.env.GLOBAL_AGENT_HTTP_PROXY) {
 let options = {
   dev: true,
   projectType: args.type,
+  subprojectName: args.subproject,
   multiProject: args.recurse,
   depth: 3,
   output: args.output,

--- a/index.js
+++ b/index.js
@@ -720,21 +720,30 @@ const createJavaBom = async (
           for (let i in sbtProjects) {
             const basePath = sbtProjects[i];
             let dlFile = pathLib.join(tempDir, "dl-" + i + ".tmp");
+            var commandPrefix = "";
+            if (options.subprojectName) {
+              commandPrefix = `${options.subprojectName}/`
+            }
+
             console.log(
               "Executing",
               SBT_CMD,
-              "dependencyList in",
+              `${commandPrefix}dependencyList in`,
               basePath,
               "using plugins",
               tempSbtgDir
             );
             var sbtArgs = [];
             var pluginFile = null;
+            var commandPrefix = "";
+            if (options.subprojectName) {
+              commandPrefix = `${options.subprojectName}/`
+            }
             if (standalonePluginFile) {
-              sbtArgs = [`-addPluginSbtFile=${tempSbtPlugins}`,`"dependencyList::toFile ${dlFile} --append"`]
+              sbtArgs = [`-addPluginSbtFile=${tempSbtPlugins}`,`"${commandPrefix}dependencyList::toFile ${dlFile} --append"`]
             } else {
               // write to the existing plugins file
-              sbtArgs = [`"dependencyList::toFile ${dlFile} --append"`]
+              sbtArgs = [`"${commandPrefix}dependencyList::toFile ${dlFile} --append"`]
               pluginFile = utils.addPlugin(basePath, sbtPluginDefinition);
             }
             // Note that the command has to be invoked with `shell: true` to properly execut sbt
@@ -751,9 +760,6 @@ const createJavaBom = async (
                 );
                 console.log(
                   `2. Check if the plugin net.virtual-void:sbt-dependency-graph 0.10.0-RC1 can be used in the environment`
-                );
-                console.log(
-                  "3. Consider creating a lockfile using sbt-dependency-lock plugin. See https://github.com/stringbean/sbt-dependency-lock"
                 );
               }
             } else if (DEBUG_MODE) {


### PR DESCRIPTION
When dealing with large and complex monorepos, even non-recursive execution
of cdxgen may unnecessairly take a really long time.
This change introduces an additional parameter, `--subproject`, which
will attempt to generate BOM only for a specific subproject of the
monorepo. Currently, only SBT projects will make use of this parameter.

Also released one of the recommendations, since it is not officially supported by SL.