### PR TITLE
fix AppImage

### DIFF
--- a/appimage-builder.yml
+++ b/appimage-builder.yml
@@ -1,14 +1,15 @@
 version: 1
 script:
   # Remove any previous build
-  - rm -rf AppDir  | true
+  - rm -rf AppDir
   # Make usr and icons dirs
   - mkdir -p AppDir/usr/{src,bin}
   - mkdir -p AppDir/usr/share/{metainfo,icons}
-  - cp appimage-reqs.sh tools_config AppDir/usr/src -r
-  - cp tools_config/io.shiftleft.cdxgen.appdata.xml AppDir/usr/share/metainfo/
-  - chmod +x AppDir/usr/src/appimage-reqs.sh && AppDir/usr/src/appimage-reqs.sh AppDir
-  - npm install --only=production --no-save --prefix AppDir/usr/local/lib yarn @appthreat/cdxgen @microsoft/rush
+  - cp -r appimage-reqs.sh tools_config AppDir/usr/src
+  - cp tools_config/io.shiftleft.cdxgen.appdata.xml AppDir/usr/share/metainfo
+  - bash AppDir/usr/src/appimage-reqs.sh AppDir
+  # install ourselves instead of pushed package for cdxgen; install plugins as well; do not use symlinks
+  - npm install --only=production --no-save --prefix AppDir/usr/local/lib --install-links . yarn @appthreat/cdxgen-plugins-bin @microsoft/rush
   - python3 -m pip install --no-cache-dir --ignore-installed --prefix=/usr --root=AppDir pipenv
 
 AppDir:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appthreat/cdxgen",
-  "version": "2.3.7",
+  "version": "2.3.14",
   "description": "Creates CycloneDX Software Bill-of-Materials (SBOM) for node.js, python, java and golang projects",
   "homepage": "http://github.com/AppThreat/cdxgen",
   "author": "Team AppThreat",


### PR DESCRIPTION
For the record, it was installing and thus also publishing <https://www.npmjs.com/package/@appthreat/cdxgen>, not our, nor the current version.

Tbd. if the changes actually, since I can't fricking test them unless they're on GitHub (I think).